### PR TITLE
include a test's setup and teardown methods in its subtest group

### DIFF
--- a/lib/Test/Roo.pm
+++ b/lib/Test/Roo.pm
@@ -5,6 +5,8 @@ package Test::Roo;
 # ABSTRACT: Composable, reusable tests with roles and Moo
 # VERSION
 
+use Test::More 0.96 import => [qw/subtest/];
+
 use Sub::Install;
 
 sub import {
@@ -31,7 +33,7 @@ sub import {
 sub test {
     my ( $name, $code ) = @_;
     my $caller = caller;
-    my $subtest = sub { shift->each_test( $name, $code ) };
+    my $subtest = sub { my $self = shift; subtest $name => sub { $self->each_test( $name, $code ) } };
     eval qq{ package $caller; after _do_tests => \$subtest };
     die $@ if $@;
 }

--- a/lib/Test/Roo/Class.pm
+++ b/lib/Test/Roo/Class.pm
@@ -115,7 +115,7 @@ will globally affect every test block, including composed ones.
 
 sub each_test {
     my ( $self, $name, $code ) = @_;
-    subtest $name => sub { $code->($self) };
+    $code->($self);
 }
 
 =method teardown 


### PR DESCRIPTION
I recently ran into a situation where assertions in setup and teardown methods were failing, but because those are run outside of the `Test::More::subtest` enclosing the test defined by `Test::Roo::test` their output was not associated with the actual test, but up one level.  I found that confusing.

This patch moves the call to `Test::More::subtest` up a level so that the setup & teardown methods are now
associated with the test.

For example, the following code:

```
use Test::Roo;

before each_test => sub { fail('setup') };
after each_test => sub { fail('teardown') };

test 'test 1' => sub { pass('main test') };

run_me;
done_testing;
```

results in this output before the patch:

```
    not ok 1 - setup
    #   Failed test 'setup'
    #   at uptest.pl line 3.
        ok 1 - main test
        1..1
    ok 2 - test 1
    not ok 3 - teardown
    #   Failed test 'teardown'
    #   at uptest.pl line 4.
    1..3
    # Looks like you failed 2 tests of 3.
not ok 1 - testing with main
```

and this after:

```
        not ok 1 - setup
        #   Failed test 'setup'
        #   at uptest.pl line 3.
        ok 2 - main test
        not ok 3 - teardown
        #   Failed test 'teardown'
        #   at uptest.pl line 4.
        1..3
        # Looks like you failed 2 tests of 3.
    not ok 1 - test 1
    #   Failed test 'test 1'
    #   at lib/Test/Roo.pm line 36.
    1..1
    # Looks like you failed 1 test of 1.
```

To my eye this is more logically and aesthetically pleasing.
